### PR TITLE
Fix Bug: 修正BUCKET_DISPLAY_NAME的值为null引发的扫描中止

### DIFF
--- a/ImagePicker/src/main/java/com/lwkandroid/imagepicker/data/ImageDataModel.java
+++ b/ImagePicker/src/main/java/com/lwkandroid/imagepicker/data/ImageDataModel.java
@@ -246,7 +246,12 @@ public class ImageDataModel
                     String height = cur.getString(imageHeightIndex);
                     String floderId = cur.getString(floderIdIndex);
                     String floderName = cur.getString(floderNameIndex);
-                    String name = cur.getString(imageNameIndex).toLowerCase();
+                    String name = cur.getString(imageNameIndex);
+                    name = name == null?imagePath:name;
+                    if (name == null) {
+                        continue;
+                    }
+                    name = name.toLowerCase();
                     //                    Log.e("ImagePicker", "imageId=" + imageId + "\n"
                     //                            + "imagePath=" + imagePath + "\n"
                     //                            + "lastModify=" + lastModify + "\n"
@@ -275,9 +280,11 @@ public class ImageDataModel
                             floderBean = floderMap.get(floderId);
                         else
                             floderBean = new ImageFloderBean(floderId, floderName);
-                        floderBean.setFirstImgPath(imagePath);
-                        floderBean.gainNum();
-                        floderMap.put(floderId, floderBean);
+                        if (floderBean != null) {
+                            floderBean.setFirstImgPath(imagePath);
+                            floderBean.gainNum();
+                            floderMap.put(floderId, floderBean);
+                        }
                     }
 
                 } while (cur.moveToNext());

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
在部分设备上发现BUCKET_DISPLAY_NAME的值为null，在执行toLowerCase时引发NullPointerException，并造成图片扫描中断，扫描结果不完整。
修改后的逻辑为，name为null时使用imagePath，如果依然为null则该跳过此条记录。
顺便为了以防万一，floderBean也加了防null处理。
望采纳